### PR TITLE
Correct docs link

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
      - "hibernate"
      - "panache"
      - "jpa"
-   guide: https://quarkiverse.github.io/quarkiverse-docs/jpastreamer/dev/
+   guide: https://github.com/quarkiverse/quarkus-jpastreamer#readme
    categories:
       - "data"
    status: "preview"


### PR DESCRIPTION
The current docs link points to a page which doesn't exist. This project's readme is very complete, so let's just use that until docs are published.