### PR TITLE
Remove warning about missing release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -105,8 +105,6 @@ In Maven, the following JPAstreamer dependency is added to the project's pom.xml
 </dependencies>
 ----
 
-WARNING: The JPAStreamer Quarkus extension has not yet been officially released with Maven, thus for now this dependency can only be used with a local snapshot version. 
-
 === Resources
 - **JPAStreamer Project** - https://github.com/speedment/jpa-streamer
 - **Documentation** - https://speedment.github.io/jpa-streamer


### PR DESCRIPTION
I can see https://search.maven.org/artifact/io.quarkiverse.jpastreamer/quarkus-jpastreamer/1.0.0/jar has been released now, so I think we can drop the warning about using snapshots, is that right?