### PR TITLE
Update surefire and failsafe to version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <maven-source-plugin-version>3.2.1</maven-source-plugin-version>
     <maven-javadoc-plugin-version>3.4.1</maven-javadoc-plugin-version>
     <maven-deploy-plugin-version>3.0.0</maven-deploy-plugin-version>
-    <maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
-    <maven-failsafe-plugin-version>2.22.2</maven-failsafe-plugin-version>
+    <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
+    <maven-failsafe-plugin-version>3.5.2</maven-failsafe-plugin-version>
     <maven-jar-plugin-version>3.2.2</maven-jar-plugin-version>
     <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
   </properties>


### PR DESCRIPTION
This version has better support, and is also likely to be necessary for Quarkus 3.21